### PR TITLE
Merge always print the unicode character not just for hangul jamos.

### DIFF
--- a/gucharmap/gucharmap-charmap.c
+++ b/gucharmap/gucharmap-charmap.c
@@ -364,15 +364,20 @@ insert_codepoint (GucharmapCharmap *charmap,
   GtkTextTag *tag;
   char buf[7];
   GUnicodeType t;
+  gboolean is_graph, is_Mn;
   char nbsp[3] = "\302\240\0"; /* U+00A0 NO-BREAK SPACE */
 
   t = g_unichar_type (uc);
+  is_Mn = t == G_UNICODE_NON_SPACING_MARK /* Mn */;
+  is_graph = g_unichar_isgraph (uc);
+
   buf[g_unichar_to_utf8 (uc, buf)] = '\0';
 
-  str = g_strdup_printf ("%s%s U+%4.4X %s",
+  str = g_strdup_printf ("%s%s%sU+%4.4X %s",
                          /* Per unicode standard, exhibit nonspacing marks on NBSP */
-                         t == G_UNICODE_NON_SPACING_MARK /* Mn */ ? nbsp : "", 
-                         buf,
+                         is_graph && is_Mn ? nbsp : "",
+                         is_graph ? buf : "",
+                         is_graph ? " " : "",
                          uc,
                          gucharmap_get_unicode_name (uc));
 


### PR DESCRIPTION
Christian Persch [gucharmap developer] 
2017-01-28 20:23:03 UTC
Thanks for the patch. I chose to implement this differently by simply making insert_codepoint always print the character too, not just for hangul jamos.
Link: https://bugzilla.gnome.org/show_bug.cgi?id=777829#c4